### PR TITLE
Fix Pytest and continuous integration with Travis; this is a combinat…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,9 @@ language: python
 
 # which python versions to test
 python:
-#  - "2.6"
-#  - "2.7"
-#  - "3.2"
-#  - "3.3"
   - "3.4"
-#  - "3.5"
-#  - "3.5-dev" # 3.5 development branch
-#  - "3.6"
-#  - "3.6-dev" # 3.6 development branch
-#  - "3.7-dev" # 3.7 development branch
-#  - "nightly"
-
-virtualenv:
-    system_site_packages: true
+  - "3.5"
+  - "3.6"
 
 # Cache directory $HOME/.cache/pip
 cache: pip
@@ -26,7 +15,9 @@ before_install:
   - sudo apt-get install gfortran
   - sudo apt-get install openmpi-bin libopenmpi-dev
   - ompi_info
-  - pip3 install -r requirements.txt
+  - python -m pip install --upgrade pip
+  - python -m pip install -r requirements.txt
+  - python -m pip uninstall -y spl
   - mkdir -p usr
   - export FORTRAN_INSTALL_DIR=$TRAVIS_BUILD_DIR/usr
   - mkdir build && cd build
@@ -36,15 +27,25 @@ before_install:
 # command to install project
 install:
   - cd build && make && make install && cd ..
-  - pip3 install --upgrade .
+  - python -m pip install .
+
+before_script:
+  - mkdir pytest
+  - cp mpi_tester.py pytest
 
 # command to run tests
 script:
-#  - pytest # or py.test for Python versions 3.5 and below
-#  - pytest tests/caid
   - cd build ; make test ; cd ..
+  - cd pytest
 # Serial tests
-  - pytest spl --ignore="spl/mapping" -m "not parallel"
+  - python -m pytest --pyargs spl.core
+  - python -m pytest --pyargs spl.feec
+  - python -m pytest --pyargs spl.utilities
+  - python -m pytest --pyargs spl.linalg -m "not parallel"
 # Parallel tests
-  - python3 mpi_tester.py spl/ddm -m "parallel"
-  - python3 mpi_tester.py spl/linalg -m "parallel"
+  - python mpi_tester.py --pyargs spl.ddm
+  - python mpi_tester.py --pyargs spl.linalg -m "parallel"
+  - cd -
+
+after_script:
+  - rm -rf pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy>=1.13
 scipy
 matplotlib
 mpi4py

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ setup_args = dict(
 )
 
 # ...
-packages = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
+packages = find_packages()
+#packages = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
 # ...
 
 # ...

--- a/spl/__init__.py
+++ b/spl/__init__.py
@@ -1,8 +1,10 @@
 # -*- coding: UTF-8 -*-
 __version__ = "0.1"
+__all__     = ['core','ddm','feec','linalg','utilities']
 
-from .core      import *
-from .linalg    import *
-#from .mapping   import *
-from .utilities import *
-from .feec      import *
+from spl import core
+from spl import ddm
+from spl import feec
+from spl import linalg
+#from . import mapping
+from spl import utilities

--- a/spl/core/__init__.py
+++ b/spl/core/__init__.py
@@ -1,4 +1,7 @@
-# -*- coding: UTF-8 -*-
-
-from .basic     import *
-from .interface import *
+try:
+    from spl.core import bsp
+    from spl.core import interface
+except ImportError:
+    pass
+else:
+    __all__ = ['bsp','interface']

--- a/spl/core/interface.py
+++ b/spl/core/interface.py
@@ -3,6 +3,20 @@
 import numpy as np
 
 from spl.utilities.quadratures import gauss_legendre
+from spl.core.bsp import bsp_utils as _core
+
+__all__ = [
+    'make_open_knots',
+    'make_periodic_knots',
+    'construct_grid_from_knots',
+    'construct_quadrature_grid',
+    'eval_on_grid_splines_ders',
+    'compute_spans',
+    'compute_greville',
+    'collocation_matrix',
+    'histopolation_matrix',
+    'mass_matrix'
+]
 
 def make_open_knots(p, n):
     """Returns an open knots sequence for n splines and degree p.
@@ -22,7 +36,6 @@ def make_open_knots(p, n):
     array([0. , 0. , 0. , 0. , 0.2, 0.4, 0.6, 0.8, 1. , 1. , 1. , 1. ])
 
     """
-    from spl.core.bsp  import bsp_utils as _core
     T = _core.make_open_knots(p, n)
     return T
 
@@ -44,7 +57,6 @@ def make_periodic_knots(p, n):
     array([-0.6 , -0.4 , -0.2 , 0. , 0.2, 0.4, 0.6, 0.8, 1. , 1.2 , 1.4 , 1.6 ])
 
     """
-    from spl.core.bsp  import bsp_utils as _core
     T = _core.make_periodic_knots(p, n)
     return T
 
@@ -73,7 +85,6 @@ def construct_grid_from_knots(p, n, T):
     array([0. , 0.2, 0.4, 0.6, 0.8, 1. ])
 
     """
-    from spl.core.bsp  import bsp_utils as _core
     grid = _core.construct_grid_from_knots(p, n, T)
     return grid
 
@@ -112,7 +123,6 @@ def construct_quadrature_grid(ne, k, u, w, grid):
     >>> points, weights = construct_quadrature_grid(ne, k, u, w, grid)
 
     """
-    from spl.core.bsp  import bsp_utils as _core
     points, weights = _core.construct_quadrature_grid(ne, k, u, w, grid)
     return points, weights
 
@@ -157,7 +167,6 @@ def eval_on_grid_splines_ders(p, n, k, d, T, points):
     >>> basis = eval_on_grid_splines_ders(p, n, k, d, T, points)
 
     """
-    from spl.core.bsp  import bsp_utils as _core
     basis = _core.eval_on_grid_splines_ders(p, n, k, d, T, points)
     return basis
 
@@ -186,7 +195,6 @@ def compute_spans(p, n, T):
     >>> spans
     array([4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0], dtype=int32)
     """
-    from spl.core.bsp  import bsp_utils as _core
     spans = _core.compute_spans(p, n, T)
     return spans
 
@@ -215,7 +223,6 @@ def compute_greville(p, n, knots):
            0.8       , 0.93333333, 1.        ])
 
     """
-    from spl.core.bsp  import bsp_utils as _core
     x = _core.compute_greville(p, n, knots)
     return x
 
@@ -249,7 +256,6 @@ def collocation_matrix(p, n, T, u):
     (7, 8)
 
     """
-    from spl.core.bsp  import bsp_utils as _core
     m = len(u)
     mat = _core.collocation_matrix(p, n, m, T, u)
     return mat
@@ -328,8 +334,6 @@ def mass_matrix(p, n, T):
            [0.00714286, 0.02857143, 0.07142857, 0.14285714]])
 
     """
-    from spl.utilities.quadratures import gauss_legendre
-
     # constructs the grid from the knot vector
     grid = construct_grid_from_knots(p, n, T)
 

--- a/spl/core/tests/test_core.py
+++ b/spl/core/tests/test_core.py
@@ -2,15 +2,15 @@
 
 import numpy as np
 
-from spl.core import make_open_knots
-from spl.core import construct_grid_from_knots
-from spl.core import construct_quadrature_grid
-from spl.core import eval_on_grid_splines_ders
-from spl.core import collocation_matrix
-from spl.core import histopolation_matrix
-from spl.core import compute_greville
+from spl.core.interface import make_open_knots
+from spl.core.interface import construct_grid_from_knots
+from spl.core.interface import construct_quadrature_grid
+from spl.core.interface import eval_on_grid_splines_ders
+from spl.core.interface import collocation_matrix
+from spl.core.interface import histopolation_matrix
+from spl.core.interface import compute_greville
 
-from spl.utilities import gauss_legendre
+from spl.utilities.quadratures import gauss_legendre
 
 def test_open_knots():
     # ...

--- a/spl/ddm/__init__.py
+++ b/spl/ddm/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ['cart']
+
+from spl.ddm import cart

--- a/spl/feec/__init__.py
+++ b/spl/feec/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+__all__ = ['utilities','derivatives']
 
-from .utilities import *
-from .derivatives import *
+from spl.feec import derivatives
+from spl.feec import utilities

--- a/spl/feec/tests/test_projector_1d.py
+++ b/spl/feec/tests/test_projector_1d.py
@@ -3,17 +3,17 @@
 import numpy as np
 from numpy import sin, cos, pi
 
-from spl.core import make_open_knots
+from spl.core.interface import make_open_knots
 
-from spl.utilities import Integral
-from spl.utilities import Interpolation
-from spl.utilities import Contribution
+from spl.utilities.integrate import Integral
+from spl.utilities.integrate import Interpolation
+from spl.utilities.integrate import Contribution
 
-from spl.feec import interpolation_matrices
-from spl.feec import mass_matrices
-from spl.feec import scaling_matrix
-from spl.feec import discrete_derivatives
-from spl.feec import get_tck
+from spl.feec.utilities   import interpolation_matrices
+from spl.feec.utilities   import mass_matrices
+from spl.feec.utilities   import scaling_matrix
+from spl.feec.utilities   import get_tck
+from spl.feec.derivatives import discrete_derivatives
 
 from scipy.interpolate import splev
 from scipy.sparse import csr_matrix, csc_matrix

--- a/spl/feec/tests/test_projector_2d.py
+++ b/spl/feec/tests/test_projector_2d.py
@@ -3,17 +3,17 @@
 import numpy as np
 from numpy import sin, cos, pi
 
-from spl.core import make_open_knots
-from spl.core import compute_greville
+from spl.core.interface import make_open_knots
+from spl.core.interface import compute_greville
 
-from spl.utilities import Integral2D
+from spl.utilities.integrate import Integral2D
 
-from spl.feec import interpolation_matrices
-from spl.feec import mass_matrices
-from spl.feec import Interpolation2D
-from spl.feec import scaling_matrix
-from spl.feec import discrete_derivatives
-from spl.feec import get_tck
+from spl.feec.utilities   import interpolation_matrices
+from spl.feec.utilities   import mass_matrices
+from spl.feec.utilities   import Interpolation2D
+from spl.feec.utilities   import scaling_matrix
+from spl.feec.utilities   import get_tck
+from spl.feec.derivatives import discrete_derivatives
 
 from scipy.interpolate import bisplev
 from scipy.sparse import csr_matrix, csc_matrix

--- a/spl/feec/utilities.py
+++ b/spl/feec/utilities.py
@@ -91,9 +91,9 @@ def mass_matrices(p, n, T):
 # ...
 def build_kron_matrix(p, n, T, kind):
     """."""
-    from spl.core import collocation_matrix
-    from spl.core import histopolation_matrix
-    from spl.core import compute_greville
+    from spl.core.interface import collocation_matrix
+    from spl.core.interface import histopolation_matrix
+    from spl.core.interface import compute_greville
 
     if not isinstance(p, (tuple, list)) or not isinstance(n, (tuple, list)):
         raise TypeError('Wrong type for n and/or p. must be tuple or list')
@@ -148,9 +148,9 @@ def interpolation_matrices(p, n, T):
     """
     # 1d case
     if isinstance(p, int):
-        from spl.core import compute_greville
-        from spl.core import collocation_matrix
-        from spl.core import histopolation_matrix
+        from spl.core.interface import compute_greville
+        from spl.core.interface import collocation_matrix
+        from spl.core.interface import histopolation_matrix
 
         grid = compute_greville(p, n, T)
 
@@ -187,8 +187,8 @@ class Interpolation2D(object):
 
     def __init__(self, p, n, T, k=None):
 
-        from spl.utilities import Integral
-        from spl.utilities import Interpolation
+        from spl.utilities.integrate import Integral
+        from spl.utilities.integrate import Interpolation
 
         if not isinstance(p, (tuple, list)) or not isinstance(n, (tuple, list)):
             raise TypeError('Wrong type for n and/or p. must be tuple or list')
@@ -243,7 +243,7 @@ class Interpolation2D(object):
             return F0, F1
 
         elif kind == 'L2':
-            from spl.utilities import integrate_2d
+            from spl.utilities.integrate import integrate_2d
 
             points = (self._integrate[0]._points, self._integrate[1]._points)
             weights = (self._integrate[0]._weights, self._integrate[1]._weights)

--- a/spl/linalg/__init__.py
+++ b/spl/linalg/__init__.py
@@ -1,6 +1,5 @@
-# -*- coding: UTF-8 -*-
+__all__ = ['basic','solvers','stencil']
 
-from .basic   import *
-from .stencil import *
-from .block   import *
-from .solvers import *
+from spl.linalg import basic
+from spl.linalg import solvers
+from spl.linalg import stencil

--- a/spl/linalg/stencil.py
+++ b/spl/linalg/stencil.py
@@ -2,11 +2,10 @@
 #
 # Copyright 2018 Yaman Güçlü
 
-from .basic import (VectorSpace as VectorSpaceBase,
-                    Vector      as VectorBase,
-                    LinearOperator)
-
-from ..ddm.cart import Cart
+from spl.linalg.basic import (VectorSpace as VectorSpaceBase,
+                              Vector      as VectorBase,
+                              LinearOperator)
+from spl.ddm.cart import Cart
 
 #===============================================================================
 class VectorSpace( VectorSpaceBase ):

--- a/spl/mapping/__init__.py
+++ b/spl/mapping/__init__.py
@@ -1,3 +1,3 @@
-# -*- coding: UTF-8 -*-
+__all__ = ['mapping']
 
-from .mapping     import *
+from spl.mapping import mapping

--- a/spl/utilities/__init__.py
+++ b/spl/utilities/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+__all__ = ['integrate','quadratures']
 
-from .quadratures import *
-from .integrate   import *
+from spl.utilities import integrate
+from spl.utilities import quadratures

--- a/spl/utilities/integrate.py
+++ b/spl/utilities/integrate.py
@@ -104,10 +104,10 @@ class Integral(object):
     """
 
     def __init__(self, p, n, T, kind='natural', k=None):
-        from spl.core import construct_grid_from_knots
-        from spl.core import compute_greville
-        from spl.core import construct_quadrature_grid
-        from spl.utilities import gauss_legendre
+        from spl.core.interface        import construct_grid_from_knots
+        from spl.core.interface        import compute_greville
+        from spl.core.interface        import construct_quadrature_grid
+        from spl.utilities.quadratures import gauss_legendre
 
         assert(kind in ['natural', 'greville'])
 
@@ -156,7 +156,7 @@ class Interpolation(object):
     """
 
     def __init__(self, p, n, T, sites=None):
-        from spl.core import compute_greville
+        from spl.core.interface import compute_greville
 
         if sites is None:
             sites = compute_greville(p, n, T)
@@ -179,10 +179,10 @@ class Contribution(object):
 
     def __init__(self, p, n, T, sites=None):
         """Returns the 1d rhs for the function f."""
-        from spl.core.interface import construct_grid_from_knots
-        from spl.core.interface import construct_quadrature_grid
-        from spl.core.interface import eval_on_grid_splines_ders
-        from spl.core.interface import compute_spans
+        from spl.core.interface        import construct_grid_from_knots
+        from spl.core.interface        import construct_quadrature_grid
+        from spl.core.interface        import eval_on_grid_splines_ders
+        from spl.core.interface        import compute_spans
         from spl.utilities.quadratures import gauss_legendre
 
         # constructs the grid from the knot vector
@@ -260,8 +260,6 @@ class Integral2D(object):
     """
 
     def __init__(self, p, n, T, k=None):
-
-        from spl.utilities import Integral
 
         if not isinstance(p, (tuple, list)) or not isinstance(n, (tuple, list)):
             raise TypeError('Wrong type for n and/or p. must be tuple or list')

--- a/spl/utilities/tests/test_integration.py
+++ b/spl/utilities/tests/test_integration.py
@@ -2,13 +2,13 @@
 
 import numpy as np
 
-from spl.core import make_open_knots
-from spl.core import construct_quadrature_grid
-from spl.core import compute_greville
+from spl.core.interface import make_open_knots
+from spl.core.interface import construct_quadrature_grid
+from spl.core.interface import compute_greville
 
-from spl.utilities import gauss_legendre
-from spl.utilities import integrate
-from spl.utilities import Integral
+from spl.utilities.quadratures import gauss_legendre
+from spl.utilities.integrate   import integrate
+from spl.utilities.integrate   import Integral
 
 def test_integrate():
     # ...


### PR DESCRIPTION
…ion of 28 commits:

[ci] In spl.core.interface move imports out of functions.
[ci] Run pytest module as a script instead of pytest binary.
[ci] Uninstall 'spl' at 'before_install' stage.
[ci] Do not use cache for pip.
[ci] Upgrade pip and make sure to use it.
[ci] Explicitly disable all caching.
[ci] Import 'bsp' module using relative path.
[ci] Explicitly remove Travis cache.
[ci] Print current directory before installation of spl with pip.
[ci] Increase verbosity during pip installation of spl.
[ci] Use full path for relative imports (library) and absolute imports (tests).
[ci] Do not use 'from .submodule import *'.
[ci] Upgrade pytest module.
[ci] Remove unnecessary '-m' flag when running script for parallel testing.
[ci] Use relative imports in 'spl.core' tests.
[ci] Roll back to using absolute imports throughout the library, as recommended by PEP8 and PEP328.
[ci] In every '__init__.py' file, add '__all__' attribute and import subpackages/modules (relative for now).
[ci] Convert relative imports to absolute also in '__init__.py' files.
[ci] Do not import 'spl.core.bsp' before building Fortran extension module.
[ci] Force Pytest to run tests against installed package.
[ci] Install tests with package.
[ci] Run tests from separate 'pytest' directory outside package tree.
[ci] Avoid running Pytest on subpackage without tests (yields exit code=5).
[ci] Run tests with multiple Python versions (3.4 and 3.6).
[ci] Do not activate system site packages for virtualenv.
[ci] Function 'numpy.block' new in Numpy version 1.13.0
[ci] Cleanup Travis configuration, add Python versions 3.5 and 3.7-dev, reactivate pip cache.
[ci] Do not test versus Python 3.7-dev: cannot install requirements.